### PR TITLE
Accept gzip encoding

### DIFF
--- a/src/main/java/com/metamx/http/client/HttpClient.java
+++ b/src/main/java/com/metamx/http/client/HttpClient.java
@@ -236,6 +236,8 @@ public class HttpClient
       httpRequest.headers().add(HttpHeaders.Names.HOST, getHost(url));
     }
 
+    httpRequest.headers().set(HttpHeaders.Names.ACCEPT_ENCODING, HttpHeaders.Values.GZIP);
+
     for (Map.Entry<String, Collection<Object>> entry : headers.asMap().entrySet()) {
       String key = entry.getKey();
 


### PR DESCRIPTION
Pipeline already includes HttpContentDecompressor, so we just need to set the proper header to receive gzip compressed content
