### PR TITLE
using addAndMabybeStart instead of add.

### DIFF
--- a/src/main/java/com/metamx/http/client/HttpClientInit.java
+++ b/src/main/java/com/metamx/http/client/HttpClientInit.java
@@ -66,7 +66,7 @@ public class HttpClientInit
           TimeUnit.MILLISECONDS,
           512
       );
-      lifecycle.addHandler(
+      lifecycle.addMaybeStartHandler(
           new Lifecycle.Handler()
           {
             @Override


### PR DESCRIPTION
Same as the issue fixed in this [PR](https://github.com/metamx/java-util/pull/21) 
Basically we have implemented a composing emitter that loads other emitters and it happens that the http emitter is added after the lifeCyle has already been started.
This PR is changing it to the method that can work even if the Lifecycle has already been started.
