### PR TITLE
Fix up deprecated API usage.

### DIFF
--- a/src/main/java/com/metamx/http/client/HttpClientInit.java
+++ b/src/main/java/com/metamx/http/client/HttpClientInit.java
@@ -17,8 +17,8 @@
 package com.metamx.http.client;
 
 import com.google.common.base.Throwables;
-import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.metamx.common.guava.CloseQuietly;
 import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.http.client.netty.HttpClientPipelineFactory;
 import com.metamx.http.client.pool.ChannelResourceFactory;
@@ -214,7 +214,7 @@ public class HttpClientInit
       throw Throwables.propagate(e);
     }
     finally {
-      Closeables.closeQuietly(in);
+      CloseQuietly.close(in);
     }
   }
 }

--- a/src/main/java/com/metamx/http/client/pool/ChannelResourceFactory.java
+++ b/src/main/java/com/metamx/http/client/pool/ChannelResourceFactory.java
@@ -97,7 +97,6 @@ public class ChannelResourceFactory implements ResourceFactory<String, ChannelFu
           sslEngine,
           SslHandler.getDefaultBufferPool(),
           false,
-          ImmediateExecutor.INSTANCE,
           timer,
           sslHandshakeTimeout
       );

--- a/src/test/java/com/metamx/http/client/pool/ResourcePoolTest.java
+++ b/src/test/java/com/metamx/http/client/pool/ResourcePoolTest.java
@@ -19,7 +19,6 @@ package com.metamx.http.client.pool;
 import com.metamx.common.ISE;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +41,7 @@ public class ResourcePoolTest
     EasyMock.replay(resourceFactory);
     pool = new ResourcePool<String, String>(
         resourceFactory,
-        new ResourcePoolConfig(2, false)
+        new ResourcePoolConfig(2)
     );
 
     EasyMock.verify(resourceFactory);


### PR DESCRIPTION
This is needed to update guava and netty.

- Replace Closeables.closeQuietly with CloseQuietly.close.
- Switch to a non-deprecated SslHandler constructor. Effect is the same, since leaving out the Executor defaults to what we were already using (ImmediateExecutor.INSTANCE)
- Switch ResourcePoolConfig constructors. Effect is the same.