### PR TITLE
Fix channel resource factory logging

### DIFF
--- a/src/main/java/com/metamx/http/client/pool/ChannelResourceFactory.java
+++ b/src/main/java/com/metamx/http/client/pool/ChannelResourceFactory.java
@@ -69,7 +69,7 @@ public class ChannelResourceFactory implements ResourceFactory<String, ChannelFu
   @Override
   public ChannelFuture generate(final String hostname)
   {
-    log.info(String.format("Generating: %s", hostname));
+    log.info("Generating: %s", hostname);
     URL url = null;
     try {
       url = new URL(hostname);


### PR DESCRIPTION
Fix for dumb way to log.

Related to https://github.com/metamx/java-util/pull/33