### PR TITLE
Allow configuration of compression codec.

### DIFF
--- a/src/main/java/com/metamx/http/client/HttpClientConfig.java
+++ b/src/main/java/com/metamx/http/client/HttpClientConfig.java
@@ -24,6 +24,35 @@ import javax.net.ssl.SSLContext;
  */
 public class HttpClientConfig
 {
+  public enum CompressionCodec
+  {
+    IDENTITY {
+      @Override
+      public String getEncodingString()
+      {
+        return "identity";
+      }
+    },
+    GZIP {
+      @Override
+      public String getEncodingString()
+      {
+        return "gzip";
+      }
+    },
+    DEFLATE {
+      @Override
+      public String getEncodingString()
+      {
+        return "deflate";
+      }
+    };
+
+    public abstract String getEncodingString();
+  }
+
+  public static final CompressionCodec DEFAULT_COMPRESSION_CODEC = CompressionCodec.GZIP;
+
   // Default from NioClientSocketChannelFactory.DEFAULT_BOSS_COUNT, which is private:
   private static final int DEFAULT_BOSS_COUNT = 1;
 
@@ -41,6 +70,7 @@ public class HttpClientConfig
   private final Duration sslHandshakeTimeout;
   private final int bossPoolSize;
   private final int workerPoolSize;
+  private final CompressionCodec compressionCodec;
 
   @Deprecated // Use the builder instead
   public HttpClientConfig(
@@ -48,7 +78,15 @@ public class HttpClientConfig
       SSLContext sslContext
   )
   {
-    this(numConnections, sslContext, Duration.ZERO, null, DEFAULT_BOSS_COUNT, DEFAULT_WORKER_COUNT);
+    this(
+        numConnections,
+        sslContext,
+        Duration.ZERO,
+        null,
+        DEFAULT_BOSS_COUNT,
+        DEFAULT_WORKER_COUNT,
+        DEFAULT_COMPRESSION_CODEC
+    );
   }
 
   @Deprecated // Use the builder instead
@@ -58,7 +96,15 @@ public class HttpClientConfig
       Duration readTimeout
   )
   {
-    this(numConnections, sslContext, readTimeout, null, DEFAULT_BOSS_COUNT, DEFAULT_WORKER_COUNT);
+    this(
+        numConnections,
+        sslContext,
+        readTimeout,
+        null,
+        DEFAULT_BOSS_COUNT,
+        DEFAULT_WORKER_COUNT,
+        DEFAULT_COMPRESSION_CODEC
+    );
   }
 
   @Deprecated // Use the builder instead
@@ -69,7 +115,15 @@ public class HttpClientConfig
       Duration sslHandshakeTimeout
   )
   {
-    this(numConnections, sslContext, readTimeout, sslHandshakeTimeout, DEFAULT_BOSS_COUNT, DEFAULT_WORKER_COUNT);
+    this(
+        numConnections,
+        sslContext,
+        readTimeout,
+        sslHandshakeTimeout,
+        DEFAULT_BOSS_COUNT,
+        DEFAULT_WORKER_COUNT,
+        DEFAULT_COMPRESSION_CODEC
+    );
   }
 
   private HttpClientConfig(
@@ -78,7 +132,8 @@ public class HttpClientConfig
       Duration readTimeout,
       Duration sslHandshakeTimeout,
       int bossPoolSize,
-      int workerPoolSize
+      int workerPoolSize,
+      CompressionCodec compressionCodec
   )
   {
     this.numConnections = numConnections;
@@ -87,6 +142,7 @@ public class HttpClientConfig
     this.sslHandshakeTimeout = sslHandshakeTimeout;
     this.bossPoolSize = bossPoolSize;
     this.workerPoolSize = workerPoolSize;
+    this.compressionCodec = compressionCodec;
   }
 
   public int getNumConnections()
@@ -119,6 +175,11 @@ public class HttpClientConfig
     return workerPoolSize;
   }
 
+  public CompressionCodec getCompressionCodec()
+  {
+    return compressionCodec;
+  }
+
   public static class Builder
   {
     private int numConnections = 1;
@@ -127,6 +188,7 @@ public class HttpClientConfig
     private Duration sslHandshakeTimeout = null;
     private int bossCount = DEFAULT_BOSS_COUNT;
     private int workerCount = DEFAULT_WORKER_COUNT;
+    private CompressionCodec compressionCodec = DEFAULT_COMPRESSION_CODEC;
 
     private Builder() {}
 
@@ -172,9 +234,23 @@ public class HttpClientConfig
       return this;
     }
 
+    public Builder withCompressionCodec(CompressionCodec compressionCodec)
+    {
+      this.compressionCodec = compressionCodec;
+      return this;
+    }
+
     public HttpClientConfig build()
     {
-      return new HttpClientConfig(numConnections, sslContext, readTimeout, sslHandshakeTimeout, bossCount, workerCount);
+      return new HttpClientConfig(
+          numConnections,
+          sslContext,
+          readTimeout,
+          sslHandshakeTimeout,
+          bossCount,
+          workerCount,
+          compressionCodec
+      );
     }
   }
 }

--- a/src/main/java/com/metamx/http/client/HttpClientConfig.java
+++ b/src/main/java/com/metamx/http/client/HttpClientConfig.java
@@ -48,6 +48,14 @@ public class HttpClientConfig
       }
     };
 
+    /**
+     * Get the header-ified name of this encoding, which should go in "Accept-Encoding" and
+     * "Content-Encoding" headers. This is not just the lowercasing of the enum name, since
+     * we may one day support x- encodings like LZ4, which would likely be an enum named
+     * "LZ4" that has an encoding string like "x-lz4".
+     *
+     * @return encoding name
+     */
     public abstract String getEncodingString();
   }
 

--- a/src/main/java/com/metamx/http/client/HttpClientInit.java
+++ b/src/main/java/com/metamx/http/client/HttpClientInit.java
@@ -92,8 +92,11 @@ public class HttpClientInit
                       config.getSslHandshakeTimeout() == null ? -1 : config.getSslHandshakeTimeout().getMillis()
                   ),
                   new ResourcePoolConfig(config.getNumConnections())
-              )
-          ).withTimer(timer).withReadTimeout(config.getReadTimeout())
+              ),
+              config.getReadTimeout(),
+              config.getCompressionCodec(),
+              timer
+          )
       );
     }
     catch (Exception e) {


### PR DESCRIPTION
In Druid we've seen that for large resultsets, gzip compression / decompression time is substantial, and given that Druid is typically deployed on a LAN we could benefit from using a different codec or from not using compression at all. This patch adds configurability between gzip/deflate/identity (the ones currently supported by the client) rather than hard-coding gzip.

Allows changing the default through `withCompressionCodec` on the config builder, as well as overriding per-request through the Accept-Encoding header.